### PR TITLE
Account for Mixin naming collisions

### DIFF
--- a/common/src/main/java/org/infernalstudios/archeryexp/mixin/AbstractArrowMixin.java
+++ b/common/src/main/java/org/infernalstudios/archeryexp/mixin/AbstractArrowMixin.java
@@ -34,8 +34,10 @@ public abstract class AbstractArrowMixin implements ArrowProperties {
     @Unique
     private int headshotLvl;
 
+    // The weird name with the mod ID prefixed is to avoid collisions with other mods that have mixins which add methods of the same name.
+    // This method was previously named "getArrow".
     @Unique
-    private AbstractArrow getArrow() {
+    private AbstractArrow archeryexp$self() {
         return (AbstractArrow) (Object) this;
     }
 
@@ -57,7 +59,7 @@ public abstract class AbstractArrowMixin implements ArrowProperties {
 
             double headPosition = living.position().add(0.0, living.getDimensions(living.getPose()).height * 0.85, 0.0).y - 0.17;
 
-            if (getHeadshotLevel() > 0 && living.canBeHitByProjectile() && getArrow().position().y > headPosition && living.getType().is(ArcheryTags.HeadshotWhitelist)) {
+            if (getHeadshotLevel() > 0 && living.canBeHitByProjectile() && archeryexp$self().position().y > headPosition && living.getType().is(ArcheryTags.HeadshotWhitelist)) {
                 hurtAmount += getHeadshotLevel() * 2;
                 playSound = true;
                 if (living.level() instanceof ServerLevel serverLevel) {
@@ -73,7 +75,7 @@ public abstract class AbstractArrowMixin implements ArrowProperties {
                 }
             }
 
-            if (playSound && getArrow().getOwner() instanceof Player player) {
+            if (playSound && archeryexp$self().getOwner() instanceof Player player) {
                 entity.level().playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.ARROW_HIT_PLAYER, entity.getSoundSource(), 1, 1);
             }
         }
@@ -97,7 +99,7 @@ public abstract class AbstractArrowMixin implements ArrowProperties {
                 }
             });
 
-            Entity arrowOwner = getArrow().getOwner();
+            Entity arrowOwner = archeryexp$self().getOwner();
 
             if (arrowOwner instanceof LivingEntity user) {
                 user.getArmorSlots().forEach(stack -> {

--- a/common/src/main/java/org/infernalstudios/archeryexp/mixin/AbstractClientPlayerMixin.java
+++ b/common/src/main/java/org/infernalstudios/archeryexp/mixin/AbstractClientPlayerMixin.java
@@ -2,30 +2,28 @@ package org.infernalstudios.archeryexp.mixin;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.AbstractClientPlayer;
-import net.minecraft.client.player.Input;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.BowItem;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import org.infernalstudios.archeryexp.ArcheryExpansion;
 import org.infernalstudios.archeryexp.util.BowProperties;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(AbstractClientPlayer.class)
 public abstract class AbstractClientPlayerMixin {
 
+    // The weird name with the mod ID prefixed is to avoid collisions with other mods that have mixins which add methods of the same name.
+    // This method was previously named "getPlayer".
     @Unique
-    private AbstractClientPlayer getPlayer() {
+    private AbstractClientPlayer archeryexp$self() {
         return (AbstractClientPlayer) (Object) this;
     }
 
@@ -35,20 +33,20 @@ public abstract class AbstractClientPlayerMixin {
             locals = LocalCapture.CAPTURE_FAILEXCEPTION,
             cancellable = true)
     private void bowSlowdown(CallbackInfoReturnable<Float> cir, float fov) {
-        ItemStack item = getPlayer().getUseItem();
-        if (getPlayer().isUsingItem()) {
+        ItemStack item = archeryexp$self().getUseItem();
+        if (archeryexp$self().isUsingItem()) {
             if (item.getItem() instanceof BowItem) {
 
                 BowProperties bow = (BowProperties) item.getItem();
 
-                AttributeInstance speedAttribute = getPlayer().getAttribute(Attributes.MOVEMENT_SPEED);
+                AttributeInstance speedAttribute = archeryexp$self().getAttribute(Attributes.MOVEMENT_SPEED);
 
                 if (speedAttribute != null) {
                     AttributeModifier drawModifier = speedAttribute.getModifier(ArcheryExpansion.BOW_DRAW_SPEED_MODIFIER_ID);
 
                     if (drawModifier != null) {
-                        float movementSpeed = (float)getPlayer().getAttributeValue(Attributes.MOVEMENT_SPEED);
-                        float walkingSpeed = getPlayer().getAbilities().getWalkingSpeed();
+                        float movementSpeed = (float) archeryexp$self().getAttributeValue(Attributes.MOVEMENT_SPEED);
+                        float walkingSpeed = archeryexp$self().getAbilities().getWalkingSpeed();
                         float multipler = bow.getMovementSpeedMultiplier();
 
                         fov /= (movementSpeed / walkingSpeed + 1.0f) / 2.0f;
@@ -56,7 +54,7 @@ public abstract class AbstractClientPlayerMixin {
                     }
                 }
 
-                int $$2 = getPlayer().getTicksUsingItem();
+                int $$2 = archeryexp$self().getTicksUsingItem();
                 float $$3 = (float)$$2 / 20.0F;
                 if ($$3 > 1.0F) {
                     $$3 = 1.0F;

--- a/common/src/main/java/org/infernalstudios/archeryexp/mixin/AbstrtactSkeletonMixin.java
+++ b/common/src/main/java/org/infernalstudios/archeryexp/mixin/AbstrtactSkeletonMixin.java
@@ -23,7 +23,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -36,8 +35,10 @@ public abstract class AbstrtactSkeletonMixin {
 
     @Shadow public abstract void setItemSlot(EquipmentSlot $$0, ItemStack $$1);
 
+    // The weird name with the mod ID prefixed is to avoid collisions with other mods that have mixins which add methods of the same name.
+    // This method was previously named "getSkeleton".
     @Unique
-    private AbstractSkeleton getSkeleton() {
+    private AbstractSkeleton archeryexp$self() {
         return (AbstractSkeleton) (Object) this;
     }
 
@@ -51,17 +52,17 @@ public abstract class AbstrtactSkeletonMixin {
     )
     private void rangedAttack(LivingEntity target, float $$1, CallbackInfo ci, ItemStack $$2, AbstractArrow arrow, double $$4, double $$5, double $$6, double $$7) {
 
-        ItemStack stack = getSkeleton().getMainHandItem();
+        ItemStack stack = archeryexp$self().getMainHandItem();
 
         int level = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.POWER_ARROWS, stack);
         if (level > 0) {
-            stack.hurtAndBreak(level, getSkeleton(), (ignore) -> {});
+            stack.hurtAndBreak(level, archeryexp$self(), (ignore) -> {});
         }
 
         BowProperties bow = (BowProperties) stack.getItem();
 
         if (bow.hasSpecialProperties()) {
-            arrow.shootFromRotation(getSkeleton(), getSkeleton().getXRot(), getSkeleton().getYRot(), 0.0f, 1.6f, (float)(14 - getSkeleton().level().getDifficulty().getId() * 4));
+            arrow.shootFromRotation(archeryexp$self(), archeryexp$self().getXRot(), archeryexp$self().getYRot(), 0.0f, 1.6f, (float)(14 - archeryexp$self().level().getDifficulty().getId() * 4));
             arrow.setBaseDamage(bow.getBaseDamage());
 
             level = EnchantmentHelper.getItemEnchantmentLevel(ArcheryEnchants.SHATTERING, stack);
@@ -71,22 +72,22 @@ public abstract class AbstrtactSkeletonMixin {
             ((ArrowProperties) arrow).setHeadshotLevel(level);
 
             bow.getEffects().forEach(potionData -> {
-                getSkeleton().addEffect(new MobEffectInstance(potionData.getEffect(), potionData.getLength(), potionData.getLevel(), true, true));
+                archeryexp$self().addEffect(new MobEffectInstance(potionData.getEffect(), potionData.getLength(), potionData.getLevel(), true, true));
             });
 
             bow.getParticles().forEach(particleData -> {
-                if (getSkeleton().level() instanceof ServerLevel serverLevel) {
+                if (archeryexp$self().level() instanceof ServerLevel serverLevel) {
 
                     Vec3 o = particleData.getPosOffset();
                     Vec3 v = particleData.getVelocity();
 
-                    Vec3 lookVector = getSkeleton().getLookAngle();
+                    Vec3 lookVector = archeryexp$self().getLookAngle();
 
-                    Vec3 inFrontPos = getSkeleton().position().add(lookVector.scale(particleData.getLookOffset()));
+                    Vec3 inFrontPos = archeryexp$self().position().add(lookVector.scale(particleData.getLookOffset()));
 
                     serverLevel.sendParticles(
                             particleData.getType(),
-                            inFrontPos.x + o.x, getSkeleton().getEyeY() + o.y, inFrontPos.z() + o.z,
+                            inFrontPos.x + o.x, archeryexp$self().getEyeY() + o.y, inFrontPos.z() + o.z,
                             particleData.getCount(),
                             v.x,
                             v.y,
@@ -106,7 +107,7 @@ public abstract class AbstrtactSkeletonMixin {
             )
     )
     private boolean modifyWeaponHand(ItemStack instance, Item $$0, Operation<Boolean> original) {
-        ItemStack handItem = getSkeleton().getMainHandItem();
+        ItemStack handItem = archeryexp$self().getMainHandItem();
         return original.call(instance, $$0) ||  handItem.getItem() instanceof BowItem;
     }
 }

--- a/common/src/main/java/org/infernalstudios/archeryexp/mixin/BowItemMixin.java
+++ b/common/src/main/java/org/infernalstudios/archeryexp/mixin/BowItemMixin.java
@@ -1,11 +1,8 @@
 package org.infernalstudios.archeryexp.mixin;
 
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -20,9 +17,7 @@ import net.minecraft.world.phys.Vec3;
 import org.infernalstudios.archeryexp.enchants.ArcheryEnchants;
 import org.infernalstudios.archeryexp.entities.ArcheryEntityTypes;
 import org.infernalstudios.archeryexp.util.*;
-import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -80,8 +75,10 @@ public abstract class BowItemMixin implements BowProperties {
         this.hasSpecialProperties = false;
     }
 
+    // The weird name with the mod ID prefixed is to avoid collisions with other mods that have mixins which add methods of the same name.
+    // This method was previously named "getItem".
     @Unique
-    private Item getItem() {
+    private Item archeryexp$self() {
         return (Item) (Object) this;
     }
 
@@ -103,7 +100,7 @@ public abstract class BowItemMixin implements BowProperties {
         }
 
         if (this.hasSpecialProperties) {
-            float shoot = BowUtil.getPowerForDrawTime($$7, (BowProperties) getItem());
+            float shoot = BowUtil.getPowerForDrawTime($$7, (BowProperties) archeryexp$self());
             arrow.shootFromRotation(user, user.getXRot(), user.getYRot(), 0.0f, shoot * getRange(), 1.0f);
 
             double damage = checkForArrowMatch(arrow, "caverns_and_chasms:large_arrow") ? getBaseDamage() + 4.0 : getBaseDamage();
@@ -123,7 +120,7 @@ public abstract class BowItemMixin implements BowProperties {
             level = EnchantmentHelper.getItemEnchantmentLevel(ArcheryEnchants.HEADSHOT, stack);
             ((ArrowProperties) arrow).setHeadshotLevel(level);
 
-            user.getCooldowns().addCooldown(getItem(), getBowCooldown());
+            user.getCooldowns().addCooldown(archeryexp$self(), getBowCooldown());
 
             this.effects.forEach(potionData -> {
                 user.addEffect(new MobEffectInstance(potionData.getEffect(), potionData.getLength(), potionData.getLevel(),

--- a/common/src/main/java/org/infernalstudios/archeryexp/mixin/ItemRendererMixin.java
+++ b/common/src/main/java/org/infernalstudios/archeryexp/mixin/ItemRendererMixin.java
@@ -12,7 +12,6 @@ import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BowItem;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
@@ -22,7 +21,6 @@ import org.infernalstudios.archeryexp.ArcheryExpansion;
 import org.infernalstudios.archeryexp.client.MockItemRenderer;
 import org.infernalstudios.archeryexp.util.BowProperties;
 import org.infernalstudios.archeryexp.util.BowUtil;
-import org.joml.Quaternionf;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -75,7 +73,7 @@ public class ItemRendererMixin {
                                 MockItemRenderer.renderItem(poseStack, bufferSource, light, shaftTex);
 
                             } else {
-                                ResourceLocation arrowTex = getArrowTexture(arrow);
+                                ResourceLocation arrowTex = archeryexp$getArrowTexture(arrow);
 
                                 MockItemRenderer.renderItem(poseStack, bufferSource, light, arrowTex);
                             }
@@ -88,8 +86,10 @@ public class ItemRendererMixin {
         }
     }
 
+    // The weird name with the mod ID prefixed is to avoid collisions with other mods that have mixins which add methods of the same name.
+    // This method was previously named "getArrowTexture".
     @Unique
-    private ResourceLocation getArrowTexture(ItemStack arrow) {
+    private ResourceLocation archeryexp$getArrowTexture(ItemStack arrow) {
         ResourceManager resourceManager = Minecraft.getInstance().getResourceManager();
 
         ResourceLocation arrowResource = BuiltInRegistries.ITEM.getKey(arrow.getItem());

--- a/common/src/main/java/org/infernalstudios/archeryexp/mixin/LivingEntityMixin.java
+++ b/common/src/main/java/org/infernalstudios/archeryexp/mixin/LivingEntityMixin.java
@@ -15,33 +15,35 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin {
 
+    // The weird name with the mod ID prefixed is to avoid collisions with other mods that have mixins which add methods of the same name.
+    // This method was previously named "getLivingEntity".
     @Unique
-    private LivingEntity getLivingEntity() {
+    private LivingEntity archeryexp$self() {
         return (LivingEntity) (Object) this;
     }
 
     @Inject(method = "tick", at = @At("HEAD"))
     private void tickStuff(CallbackInfo ci) {
 
-        if (getLivingEntity().isUsingItem() && getLivingEntity().getUseItem().getItem() instanceof BowItem) {
-            getLivingEntity().getArmorSlots().forEach(stack -> {
-                int level = EnchantmentHelper.getEnchantmentLevel(ArcheryEnchants.GRIT, getLivingEntity());
+        if (archeryexp$self().isUsingItem() && archeryexp$self().getUseItem().getItem() instanceof BowItem) {
+            archeryexp$self().getArmorSlots().forEach(stack -> {
+                int level = EnchantmentHelper.getEnchantmentLevel(ArcheryEnchants.GRIT, archeryexp$self());
                 if (level > 0) {
-                    getLivingEntity().addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 5, level - 1, false, false));
+                    archeryexp$self().addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 5, level - 1, false, false));
                 }
             });
         }
 
-        getLivingEntity().getArmorSlots().forEach(stack -> {
-            int level = EnchantmentHelper.getEnchantmentLevel(ArcheryEnchants.PINCUSHIONING, getLivingEntity());
+        archeryexp$self().getArmorSlots().forEach(stack -> {
+            int level = EnchantmentHelper.getEnchantmentLevel(ArcheryEnchants.PINCUSHIONING, archeryexp$self());
             if (level > 0) {
-                getLivingEntity().addEffect(new MobEffectInstance(ArcheryEffects.QUICKDRAW_EFFECT, 30, level - 1, false, false));
+                archeryexp$self().addEffect(new MobEffectInstance(ArcheryEffects.QUICKDRAW_EFFECT, 30, level - 1, false, false));
             }
 
             level = EnchantmentHelper.getItemEnchantmentLevel(ArcheryEnchants.SCOUTING, stack);
 
-            if (level > 0 && getLivingEntity().isUsingItem() && getLivingEntity().getUseItem().getItem() instanceof BowItem) {
-                getLivingEntity().addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, 30, level - 1, false, false));
+            if (level > 0 && archeryexp$self().isUsingItem() && archeryexp$self().getUseItem().getItem() instanceof BowItem) {
+                archeryexp$self().addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, 30, level - 1, false, false));
             }
         });
     }

--- a/common/src/main/java/org/infernalstudios/archeryexp/mixin/LocalPlayerMixin.java
+++ b/common/src/main/java/org/infernalstudios/archeryexp/mixin/LocalPlayerMixin.java
@@ -1,10 +1,7 @@
 package org.infernalstudios.archeryexp.mixin;
 
-import net.minecraft.client.player.Input;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BowItem;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.infernalstudios.archeryexp.util.BowProperties;
 import org.spongepowered.asm.mixin.Mixin;
@@ -21,24 +18,26 @@ public abstract class LocalPlayerMixin {
 
     @Shadow protected int sprintTriggerTime;
 
+    // The weird name with the mod ID prefixed is to avoid collisions with other mods that have mixins which add methods of the same name.
+    // This method was previously named "getPlayer".
     @Unique
-    private LocalPlayer getPlayer() {
+    private LocalPlayer archeryexp$self() {
         return (LocalPlayer) (Object) this;
     }
 
     @Inject(method = "serverAiStep", at = @At("TAIL"))
     private void bowSlowdown(CallbackInfo ci) {
 
-        ItemStack bowStack = getPlayer().getUseItem();
+        ItemStack bowStack = archeryexp$self().getUseItem();
 
-        if (getPlayer().isUsingItem() && !getPlayer().isPassenger() && this.isControlledCamera()
+        if (archeryexp$self().isUsingItem() && !archeryexp$self().isPassenger() && this.isControlledCamera()
                 && bowStack.getItem() instanceof BowItem) {
 
             BowProperties bow = (BowProperties) bowStack.getItem();
 
             if (bow.hasSpecialProperties()) {
-                getPlayer().xxa /= 0.2f; // side
-                getPlayer().zza /= 0.2f; // front/back
+                archeryexp$self().xxa /= 0.2f; // side
+                archeryexp$self().zza /= 0.2f; // front/back
             }
         }
     }

--- a/common/src/main/java/org/infernalstudios/archeryexp/mixin/PlayerMixin.java
+++ b/common/src/main/java/org/infernalstudios/archeryexp/mixin/PlayerMixin.java
@@ -42,18 +42,20 @@ public abstract class PlayerMixin {
         this.lastFOV = 0;
     }
 
+    // The weird name with the mod ID prefixed is to avoid collisions with other mods that have mixins which add methods of the same name.
+    // This method was previously named "getPlayer".
     @Unique
-    private Player getPlayer() {
+    private Player archeryexp$player() {
         return (Player) (Object) this;
     }
 
     @Inject(method = "tick", at = @At("HEAD"))
     private void playerTick(CallbackInfo ci) {
 
-        Player user = getPlayer();
+        Player user = archeryexp$player();
         ItemStack bowStack = user.getUseItem();
 
-        AttributeInstance speedAttribute = getPlayer().getAttribute(Attributes.MOVEMENT_SPEED);
+        AttributeInstance speedAttribute = user.getAttribute(Attributes.MOVEMENT_SPEED);
 
         if (user.isUsingItem() && bowStack.getItem() instanceof BowItem bow) {
 
@@ -88,7 +90,7 @@ public abstract class PlayerMixin {
             }
         }
 
-        if (!getPlayer().level().isClientSide()) {
+        if (!archeryexp$player().level().isClientSide()) {
             if (!ArcheryExpansion.bowStatPlayerList.contains((ServerPlayer) user)) {
                 for (Item item : BuiltInRegistries.ITEM) {
                     if (item instanceof BowItem bowItem) {
@@ -113,7 +115,7 @@ public abstract class PlayerMixin {
 
     @Inject(method = "attack", at = @At("HEAD"))
     private void applyQuickshot(Entity target, CallbackInfo ci) {
-        if (isCritting(target) && getPlayer().getMainHandItem().is(ItemTags.AXES)) {
+        if (isCritting(target) && archeryexp$player().getMainHandItem().is(ItemTags.AXES)) {
             LivingEntity living = (LivingEntity) target;
 
             living.getHandSlots().forEach(stack -> {
@@ -139,17 +141,17 @@ public abstract class PlayerMixin {
     @Unique
     private boolean isCritting(Entity target) {
         // Borrowing this from player
-        float $$4 = getPlayer().getAttackStrengthScale(0.5F);
+        float $$4 = archeryexp$player().getAttackStrengthScale(0.5F);
         boolean $$5 = $$4 > 0.9F;
         boolean $$8 = $$5
-                && getPlayer().fallDistance > 0.0F
-                && !getPlayer().onGround()
-                && !getPlayer().onClimbable()
-                && !getPlayer().isInWater()
-                && !getPlayer().hasEffect(MobEffects.BLINDNESS)
-                && !getPlayer().isPassenger()
+                && archeryexp$player().fallDistance > 0.0F
+                && !archeryexp$player().onGround()
+                && !archeryexp$player().onClimbable()
+                && !archeryexp$player().isInWater()
+                && !archeryexp$player().hasEffect(MobEffects.BLINDNESS)
+                && !archeryexp$player().isPassenger()
                 && target instanceof LivingEntity;
-        $$8 = $$8 && !getPlayer().isSprinting();
+        $$8 = $$8 && !archeryexp$player().isSprinting();
 
         return $$8;
     }


### PR DESCRIPTION
The mixins in this mod use utility methods in order to avoid casting "this" to `([TYPE]) (Object) this`. Unfortunately, there are some mods with mixins whose methods have generic names and are not names unique enough (for example by prefixing their mod ID to the method name). This is most commonly done by modders mixing in interfaces into the target class, usually with names that are not prefixed with their mod ID. So, a naming collision occurs and it's entirely possible that a super-interface issue can happen with missing or incorrectly implemented methods.

This PR is a quick and dirty fix that simply renames those utility methods by prefixing `archeryexp$` in front of them. In a perfect world, all modders would be more careful about adding interfaces to classes that do not have unique names, but it is simply safer to account for it on our end to reduce headaches.

- Fixes #15